### PR TITLE
Fix Mesa server launch parameters

### DIFF
--- a/VisualizeEconomy.py
+++ b/VisualizeEconomy.py
@@ -120,6 +120,6 @@ chart = ChartModule([
 )
 #text = TextElement(js_code="document.write(5 + 6);")
 
-server = ModularServer(WealthModel, [grid, chart], "Wealth Model", economy_scale*economy_scale, economy_scale, economy_scale)
+server = ModularServer(WealthModel, [grid, chart], "Wealth Model", {'N': economy_scale*economy_scale, 'width': economy_scale, 'height': economy_scale})
 server.port = 8521
 server.launch()


### PR DESCRIPTION
I'm at the cryptolife Hackathon and couldn't launch the VisualizeEconomy.py file in Python3 with the latest Mesa:

https://github.com/projectmesa/mesa/blob/c40c4183b6062542b75d1e1947d5624dc5e1b659/mesa/visualization/ModularVisualization.py#L251-L252
```Python
    def __init__(self, model_cls, visualization_elements, name="Mesa Model",
                 model_params={}):
```

I get the error:

```bash
$  python VisualizeEconomy.py
Traceback (most recent call last):
  File "VisualizeEconomy.py", line 123, in <module>
    server = ModularServer(WealthModel, [grid, chart], "Wealth Model", economy_scale*economy_scale, economy_scale, economy_scale)
TypeError: __init__() takes from 3 to 5 positional arguments but 7 were given
```

Removing the last 3 gives:

```bash
TypeError: __init__() missing 3 required positional arguments: 'N', 'width', and 'height'
```

So I guess this should fix it.