### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ jupyter==1.0.0
 
 coverage==4.1
 nose==1.3.7
-tornado==4.0.2
+tornado==4.3
 flake8==2.5.2
 tqdm


### PR DESCRIPTION
Updating tornado to version 4.3 to resolve dependency issues.

From install logs using the current requirements:
```
mesa 0.8.4 has requirement tornado<5.0.0,>=4.2, but you'll have tornado 4.0.2 which is incompatible.
jupyter-client 5.2.3 has requirement tornado>=4.1, but you'll have tornado 4.0.2 which is incompatible.
ipykernel 5.1.0 has requirement tornado>=4.2, but you'll have tornado 4.0.2 which is incompatible.
```